### PR TITLE
Fixed spec requires for Ruby 1.9.x

### DIFF
--- a/spec/delorean_spec.rb
+++ b/spec/delorean_spec.rb
@@ -1,6 +1,6 @@
 require 'rubygems'
 require 'active_support/all'
-require File.dirname(__FILE__) + "/../lib/delorean"
+require File.expand_path("../lib/delorean", File.dirname(__FILE__))
 
 describe Delorean do
 


### PR DESCRIPTION
Do not make assumptions about load path. Specs now run with Ruby 1.9.x, although some of them fail with Ruby 1.9.3.
