### PR TITLE
Fix #10, Support DateTime.now in ruby 1.9.3

### DIFF
--- a/lib/delorean.rb
+++ b/lib/delorean.rb
@@ -68,4 +68,12 @@ if RUBY_VERSION >= "1.9.3"
       Date.civil(t.year, t.mon, t.mday)
     end
   end
+
+  class << DateTime
+    alias_method :now_without_delorean, :now
+
+    def now(sg=Date::ITALY)
+      Time.now.to_datetime
+    end
+  end
 end

--- a/spec/delorean_spec.rb
+++ b/spec/delorean_spec.rb
@@ -48,6 +48,13 @@ describe Delorean do
         Time.now.should be_close(datetime, 1)
       end
     end
+
+    it "should change the result of DateTime" do
+      datetime = DateTime.strptime("2011-05-25 18:00", "%Y-%m-%d %H:%M")
+      Delorean.time_travel_to(datetime) do
+        DateTime.now.should be_close(datetime, 1)
+      end
+    end
   end
 
   describe "back_to_the_present" do


### PR DESCRIPTION
Return Time.now.to_datetime
