### PR TITLE
Specify TimeZone before running tests

### DIFF
--- a/spec/delorean_spec.rb
+++ b/spec/delorean_spec.rb
@@ -4,6 +4,15 @@ require File.expand_path("../lib/delorean", File.dirname(__FILE__))
 
 describe Delorean do
 
+  before(:all) do
+    @default_tz = ENV['TZ']
+    ENV['TZ'] = 'UTC'
+  end
+
+  after(:all) do
+    ENV['TZ'] = @default_tz
+  end
+
   after(:each) do
     Delorean.back_to_the_present
   end


### PR DESCRIPTION
In Japan, the test failed with the following message.

  'Delorean time_travel_to with block should travel through time several times' FAILED
  expected: Thu, 01 Jan 2009,
       got: Fri, 02 Jan 2009 (using ==)

The test should set running envrionment(UTC) by itself, or convert all date and time to UTC.
